### PR TITLE
feat: add currency entity and remove the defaultCurrency field inside…

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/currency/Currency.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/currency/Currency.java
@@ -1,0 +1,46 @@
+package com.finflow.finflowbackend.currency;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(
+        name = "currencies"
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Currency {
+
+    @Id
+    @Column(length = 3)
+    private String code; //ISO 4217, e.g. SGD
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int decimalScale;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    public Currency(String code, String name, int decimalScale, boolean active) {
+        if (code == null || code.length() < 3) {
+            throw new IllegalArgumentException("code length should be at least 3 characters");
+        }
+
+        if (decimalScale < 0) {
+            throw new IllegalArgumentException("decimalScale should be at least 0");
+        }
+
+        this.code = code;
+        this.name = name;
+        this.decimalScale = decimalScale;
+        this.active = active;
+    }
+}

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/user/User.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/user/User.java
@@ -2,6 +2,7 @@ package com.finflow.finflowbackend.user;
 
 import com.finflow.finflowbackend.common.enums.AuthMethod;
 import com.finflow.finflowbackend.common.enums.UserStatus;
+import com.finflow.finflowbackend.currency.Currency;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -56,10 +57,6 @@ public class User {
 
     @Column(nullable = false)
     private String timeZone;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private CurrencySupported defaultCurrency;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)


### PR DESCRIPTION
## Description

This PR introduces the initial **Currency reference domain entity** for the FinFlow backend.  
The goal is to establish a stable, extensible foundation for currency flow, exchange, and future domain relationships (accounts, transactions, budgets).

The implementation focuses on correctness, schema hygiene, and forward compatibility rather than feature completeness.

---

## Scope of Changes

- Introduced `Currency` entity with:
  - Unique currency identifier - ISO 4217
  - Core identity fields
- Defined base constraints aligned with domain ownership and security requirements, such as decimal scale needs to be at least 0 or more, and the ISO cod needs to be exactly 3 digits
- Prepared the entity for future associations (accounts, transactions, budgets) without over-coupling

---

## Design Considerations

- Entity kept intentionally minimal to avoid premature domain coupling
- Structure aligns with future:
  - Open-banking integrations
  - Ledger-grade transaction ownership
