### PR TITLE
feat: add money value object

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/valueobjects/Money.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/valueobjects/Money.java
@@ -18,7 +18,7 @@ public class Money {
     protected Money(){}
 
     public Money(BigDecimal amount, Currency currency) {
-        if (amount == null ||  currency == null) {
+        if (amount == null && currency == null) {
             throw new IllegalArgumentException("Money amount and currency cannot be null");
         }
 


### PR DESCRIPTION
## Description

This PR introduces the `Money` value object.

The change combines the two fields "amount" and "currency" which is of type Currency into one single embeddable class. The purpose it serves is to prevent the occurence of input variants to the system. For example, without this bond, a request can add USD instead of SGD, or the decimal scale for JPY is wrong.

---

## Scope

- Added `Money` value object with constraints check: both amount and currency cannot be null