### PR TITLE
feat: add TransactionOrigin enum

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/common/enums/TransactionOrigin.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/common/enums/TransactionOrigin.java
@@ -1,0 +1,7 @@
+package com.finflow.finflowbackend.common.enums;
+
+public enum TransactionOrigin {
+    USER,
+    SYSTEM,
+    EXTERNAL_PROVIDER
+}


### PR DESCRIPTION
## Description

This PR introduces the `TransactionOrigin` enum.

The purpose is to keep track of the origin or where did we get the source (user transactions) from, either from the open banking provider, or local bank providers, or from user manually upload themselves, or even system adjustments to compare between two sets of record to look for any adjustments.

---

## Scope

- Added `TransactionOrigin` enum

---

## Notes

- Change is intentionally minimal and scoped to domain modeling