### PR TITLE
feat: add Category entity with constraints check, state chagnes methods

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/category/Category.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/category/Category.java
@@ -1,0 +1,96 @@
+package com.finflow.finflowbackend.category;
+
+import com.finflow.finflowbackend.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "categories",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "name"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Setter
+    @Column
+    private String icon;
+
+    @Column(nullable = false)
+    private String colorHex;
+
+    @Column(nullable = false)
+    private boolean systemDefined;
+
+    @Column
+    private Instant deletedAt;
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void softDelete() {
+        if (!isDeleted()) {
+            return;
+        }
+        if (this.systemDefined) {
+            throw new IllegalStateException("Cannot delete system defined category");
+        }
+        this.deletedAt = Instant.now();
+    }
+
+    public void rename(String name) {
+        if (this.systemDefined) {
+            throw new IllegalStateException("Cannot rename system defined category");
+        }
+        this.name = name;
+    }
+
+    public static Category create(User user, String name, String colorHex, boolean systemDefined) {
+        validateCategoryInput(name, colorHex);
+
+        Category category = new Category();
+        category.user = Objects.requireNonNull(user);
+        category.name = Objects.requireNonNull(name);
+        category.colorHex = Objects.requireNonNull(colorHex);
+        category.systemDefined = systemDefined;
+        return category;
+    }
+
+    public static Category createUserCategory(User user, String name, String colorHex) {
+        return create(user, name, colorHex, false);
+    }
+
+    public static Category createSystemCategory(User user, String name, String colorHex) {
+        return create(user, name, colorHex, true);
+    }
+
+    private static void validateCategoryInput(String name, String colorHex) {
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("Category name is required");
+        }
+
+        if (!colorHex.matches("^#[0-9A-Fa-f]{6}$")) {
+            throw new IllegalArgumentException("Invalid color hex");
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces the initial **User domain entity** for the FinFlow backend.  
The goal is to establish a stable, extensible foundation for authentication, ownership, and future domain relationships (accounts, transactions, budgets).

The implementation focuses on correctness, schema hygiene, and forward compatibility rather than feature completeness.

---

## Scope of Changes

- Introduced `Category` entity with:
  - Unique category identifier
  - Core identity fields
  - Audit timestamps
- Defined base constraints aligned with domain ownership and security requirements
- Prepared the entity for future associations (users, transactions, budgets) without over-coupling

---

## Design Considerations

- Factory methods rather than constructor to show business intent, also helps to refactor the code easier in the future if any rule changes
- Customized setter methods, not default @Setter
- softDelete always, very important in fintech system design