### PR TITLE
feat: transaction entity

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/Transaction.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/Transaction.java
@@ -1,6 +1,8 @@
 package com.finflow.finflowbackend.transaction;
 
 import com.finflow.finflowbackend.account.Account;
+import com.finflow.finflowbackend.category.Category;
+import com.finflow.finflowbackend.common.enums.CounterpartyType;
 import com.finflow.finflowbackend.common.enums.TransactionDirection;
 import com.finflow.finflowbackend.common.enums.TransactionOrigin;
 import com.finflow.finflowbackend.common.enums.TransactionType;
@@ -11,11 +13,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
 @Table(
-        name = "transactions"
+        name = "transactions",
+        indexes = {
+                @Index(name = "idx_transaction_date", columnList = "account_id, posted_date"),
+                @Index(name = "idx_transaction_category", columnList = "category_id")
+        }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -32,7 +39,7 @@ public class Transaction {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private TransactionOrigin source;
+    private TransactionOrigin origin;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -43,13 +50,88 @@ public class Transaction {
     private TransactionType type;
 
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(
+                    name = "amount",
+                    column = @Column(name = "transaction_amount", nullable = false)
+            ),
+            @AttributeOverride(
+                    name = "currency",
+                    column = @Column(name = "transaction_currency", nullable = false)
+            )
+    })
     private Money transactionMoney;
 
-    @Column(nullable = false)
-    private LocalDate transactionDate;
+    @Column(name = "posted_date", nullable = false)
+    private LocalDate postedDate;
 
-    @Column
+    @Column(length = 255)
     private String reference;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TransactionStatus transactionStatus;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category transactionCategory;
+
+//    @Column(nullable = false)
+//    private boolean recurring = false; //This does not scale
+
+    @Column(nullable = false, length = 255)
+    private String counterpartyName = "UNKNOWN";
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CounterpartyType counterpartyType;
+
+    public static Transaction createTransaction(
+            Account account,
+            Money money,
+            LocalDate postedDate,
+            TransactionDirection direction,
+            TransactionType type,
+            TransactionOrigin origin,
+            String counterpartyName,
+            CounterpartyType counterpartyType
+    ) {
+        Transaction transaction = new Transaction();
+        transaction.account = Objects.requireNonNull(account, "account is required");
+        transaction.transactionMoney = Objects.requireNonNull(money, "money is required");
+        transaction.postedDate = Objects.requireNonNull(postedDate,  "postedDate is required");
+        transaction.counterpartyName = normalizeOrDefault(counterpartyName);
+        transaction.counterpartyType = Objects.requireNonNull(counterpartyType, "counterpartyType is required");
+        transaction.direction = Objects.requireNonNull(direction, "direction is required");
+        transaction.type = Objects.requireNonNull(type,  "type is required");
+        transaction.origin = Objects.requireNonNull(origin,  "origin is required");
+        transaction.transactionStatus = TransactionStatus.POSTED;
+        return transaction;
+    }
+
+    public void updateReference(String reference) {
+        this.reference = normalizeReference(reference);
+    }
+
+    private static String normalizeReference(String reference) {
+        if (reference == null) {
+            return null;
+        }
+        String trimmedReference =  reference.trim();
+        if (trimmedReference.isEmpty()) {
+            return null;
+        }
+        return trimmedReference.length() > 255 ? trimmedReference.substring(0, 255) : trimmedReference;
+    }
+
+    private static String normalizeOrDefault(String counterpartyName) {
+        if (counterpartyName == null) {
+            return "UNKNOWN";
+        }
+        String trimmedCounterpartyName = counterpartyName.trim();
+        if (trimmedCounterpartyName.isEmpty()) {
+            return "UNKNOWN";
+        }
+        return trimmedCounterpartyName.length() > 255 ? trimmedCounterpartyName.substring(0, 255) : trimmedCounterpartyName;
+    }
 }


### PR DESCRIPTION
## Description

This PR introduces the initial **User domain entity** for the FinFlow backend.  
The goal is to establish a stable, extensible foundation for authentication, ownership, and future domain relationships (accounts, transactions, budgets).

The implementation focuses on correctness, schema hygiene, and forward compatibility rather than feature completeness.

---

## Scope of Changes

- Introduced `Transaction` entity with:
  - Unique user identifier
  - Core identity fields
  - Audit timestamps
- Defined multiple formatting helper methods for user updating references and also extracting counterparty name field from the input; By setting the max characters to be 255, which is the industry standard, and set the field to be null if no reference / counterparty name has been provided, it enforces a good constraint check on these two invariants.
- Defined the core factory method to make the Transaction creation easier; also with the non-null checks, it lets the program to "fail fast" if any error occurs, we will let the error to show at the entity creation stage, which is super important in fintech system design, because it's better to let the "fail" to happen fast than happen after it has run a heavy load of code.

---

## Design Considerations

- No bidirectional relationships added at this stage to prevent JPA complexity and query inflation
- Structure aligns with future:
  - Open-banking integrations
  - Ledger-grade transaction ownership