### PR TITLE
fix: update TransactionOrigin enum

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/common/enums/TransactionOrigin.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/common/enums/TransactionOrigin.java
@@ -3,5 +3,6 @@ package com.finflow.finflowbackend.common.enums;
 public enum TransactionOrigin {
     USER,
     SYSTEM,
-    EXTERNAL_PROVIDER
+    IMPORT,
+    OPEN_BANKING
 }


### PR DESCRIPTION
## Description

In this PR, I updated the `TransactionOrigin` enum.

---

## Scope of Change

- Removed the `EXTERNAL_PROVIDER` constants
- Added `IMPORT`, `OPEN_BANKING` constants

---

## Design Consideration

The reason for the changes is to get rid of the ambiguity around the `EXTERNAL_PROVIDER` constant as this term is too vague that can possibly mess up with other semantics. Therefore, it's better to break it down into two smaller subtypes, `IMPROT` and `OPEN_BANKING`.