### PR TITLE
fix: change the order of the tables created inside the init migration…

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/account/Account.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/account/Account.java
@@ -56,7 +56,7 @@ public class Account extends BaseEntity {
     )
     private Money accountMoney;
 
-    @Column(precision = 19, scale = 4)
+    @Column(precision = 19, scale = 6)
     private BigDecimal creditLimit; //DO NOT ADD THIS IN THE MVP MIGRATION SCRIPTS.
 
     @Column(nullable = false)

--- a/finflow-backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/finflow-backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -25,6 +25,13 @@ CREATE TABLE users (
         )
 );
 
+CREATE TABLE currencies (
+    code VARCHAR(3) PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    decimal_scale INT NOT NULL CHECK (decimal_scale > 0),
+    active BOOLEAN NOT NULL DEFAULT TRUE
+);
+
 CREATE TABLE accounts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL,
@@ -35,6 +42,7 @@ CREATE TABLE accounts (
     institution_code VARCHAR(40) NOT NULL,
     account_balance DECIMAL(19, 6) NOT NULL DEFAULT 0,
     currency_code VARCHAR(10) NOT NULL,
+    credit_limit DECIMAL(19, 6),
     active BOOLEAN NOT NULL DEFAULT TRUE,
     closed_at TIMESTAMPTZ,
 
@@ -46,6 +54,24 @@ CREATE TABLE accounts (
 
     CONSTRAINT fk_account_currency
         FOREIGN KEY (currency_code) REFERENCES currencies(code)
+);
+
+CREATE TABLE categories (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    icon VARCHAR(50),
+    color_hex VARCHAR(7) NOT NULL,
+    system_defined BOOLEAN NOT NULL DEFAULT FALSE,
+    deleted_at TIMESTAMPTZ,
+
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT fk_category_user
+        FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+
+    CONSTRAINT uq_category_user_name UNIQUE (user_id, name)
 );
 
 CREATE TABLE transactions (
@@ -74,30 +100,5 @@ CREATE TABLE transactions (
 
     CONSTRAINT fk_transaction_category
         FOREIGN KEY (category_id) REFERENCES categories(id)
-);
-
-CREATE TABLE currencies (
-    code CHAR(3) PRIMARY KEY,
-    name VARCHAR(100) NOT NULL,
-    decimal_scale INT NOT NULL CHECK (decimal_scale > 0),
-    active BOOLEAN NOT NULL DEFAULT TRUE
-);
-
-CREATE TABLE categories (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL,
-    name VARCHAR(50) NOT NULL,
-    icon VARCHAR(50),
-    color_hex VARCHAR(7) NOT NULL,
-    system_defined BOOLEAN NOT NULL DEFAULT FALSE,
-    deleted_at TIMESTAMPTZ,
-
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL,
-
-    CONSTRAINT fk_category_user
-        FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
-
-    CONSTRAINT uq_category_user_name UNIQUE (user_id, name)
 );
 


### PR DESCRIPTION
## Description

This PR has moved the order of the tables being created inside the initial migration file.

---

## Scope of Change

- Move `currencies` table right after the `users` table, before `accounts` table and `transactions` table.
- Move `categories` table right after the `accounts` table, before the `transactions` table.
- Change the scale of creditLimit field inside the `Account` entity to 6.

---

## Reason for this change

The reason was mainly due to the fact that both `accounts` table and `transactions` table all have a column that reference the `currencies` table. However, since flyway runs through the migration file from the top to bottom and create tables as it goes; if the `currencies` table is placed after both the `accounts` and `transactions` table, then we cannot reference the currency-related columns inside both tables.