### PR TITLE
feat: add PeriodType enum and aligned the Budget entity periodType field

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/budget/Budget.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/budget/Budget.java
@@ -1,6 +1,7 @@
 package com.finflow.finflowbackend.budget;
 
 import com.finflow.finflowbackend.category.Category;
+import com.finflow.finflowbackend.common.enums.PeriodType;
 import com.finflow.finflowbackend.common.persistence.BaseEntity;
 import com.finflow.finflowbackend.user.User;
 import com.finflow.finflowbackend.valueobjects.Money;
@@ -9,7 +10,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
 import java.util.UUID;

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/common/enums/PeriodType.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/common/enums/PeriodType.java
@@ -1,0 +1,10 @@
+package com.finflow.finflowbackend.common.enums;
+
+public enum PeriodType {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    QUARTERLY,
+    ANNUALLY,
+    CUSTOM
+}


### PR DESCRIPTION
## Description

This PR introduces the `PeriodType` enum as well as aligned the periodType property inside the Budget entity.
The purpose of this is to let users set their budget duration.

---

## Scope of Change

The common constant values are:
- `DAILY`
- `WEEKLY`
- `MONTHLY`
- `QUARTERLY`
- `ANNUALLY`

With the option to let users to customize the period with the `CUSTOM` constant.