### PR TITLE
feat: add user patch dto, swagger ui, update application env config files

### DIFF
--- a/finflow-backend/pom.xml
+++ b/finflow-backend/pom.xml
@@ -34,7 +34,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.15</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/user/User.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/user/User.java
@@ -21,7 +21,6 @@ import java.util.UUID;
         name = "users"
 )
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class User extends BaseEntity {

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/user/dto/UserPatchDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/user/dto/UserPatchDto.java
@@ -1,0 +1,22 @@
+package com.finflow.finflowbackend.user.dto;
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+
+public record UserPatchDto(
+    @Size(min = 1, max = 50)
+    String firstName,
+
+    @Size(min = 1, max = 50)
+    String lastName,
+
+    @Pattern(regexp = "^\\+[1-9]\\d{7,14}$")
+    String phoneNumber,
+
+    @Past
+    LocalDate dateOfBirth,
+
+    @Size(max = 50)
+    String timeZone
+) {}

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/user/dto/UserUpdateDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/user/dto/UserUpdateDto.java
@@ -1,4 +1,0 @@
-package com.finflow.finflowbackend.user.dto;
-
-public record UserUpdateDto() {
-}

--- a/finflow-backend/src/main/resources/application-local.yml
+++ b/finflow-backend/src/main/resources/application-local.yml
@@ -11,3 +11,10 @@ spring:
 
   jpa:
     show-sql: true
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    path: /swagger-ul.html

--- a/finflow-backend/src/main/resources/application-prod.yml
+++ b/finflow-backend/src/main/resources/application-prod.yml
@@ -1,1 +1,6 @@
 # This file contains all profile / startup info for prod env
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
## Description

This PR introduces the `UserPatchDto` to act as a Data Transfer Object (DTO) to receive the requests from the frontend and sends the requests to the backend to process. It also included some minor changes which will be discussed inside the `Scope of Change` section.

---

## Scope of Change

- `UserPatchDto`
- swagger UI enabled
- updated `application-local.yml`
- updated `application-prod.yml`

---

## Design Consideration

`UserPatchDto` uses the `record` type, which is the superior choice for quickly load and unload data compared to the traditional Data Transfer Objects, which relies on the traditional `class` type. 
A quick benefit of using `record` rather than `class` is that it comes with boilerplate code, such as getter, setter, hash and equal methods etc.