### PR TITLE
feat: add account rename dto

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/account/Account.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/account/Account.java
@@ -6,6 +6,7 @@ import com.finflow.finflowbackend.common.persistence.BaseEntity;
 import com.finflow.finflowbackend.user.User;
 import com.finflow.finflowbackend.valueobjects.Money;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -43,7 +44,7 @@ public class Account extends BaseEntity {
     private String providerAccountName;
 
     //The account name users can customize
-    @Column
+    @Column(name = "account_display_name", length = 30)
     private String accountDisplayName;
 
     @Column(nullable = false, length = 4)

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/account/dto/AccountRenameDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/account/dto/AccountRenameDto.java
@@ -1,0 +1,10 @@
+package com.finflow.finflowbackend.account.dto;
+
+import jakarta.validation.constraints.*;
+
+public record AccountRenameDto(
+    @NotNull
+    @NotBlank
+    @Size(min = 1, max = 30)
+    String accountDisplayName
+) {}


### PR DESCRIPTION
## Description

In this PR, I introduced yet another DTO, and that is --- `AccountRenameDto`. The purpose is simple, and that is to carry the information of the user's new account display name if they choose to customize it.
I also set rules for this dto property, besides the `@NotNull` and `@NotBlank`, I enforced a maximum of 30 characters allowed for this field.

---

## Scope of Change

- Added `AccountRenameDto` with rules check.
- Enforced a max of 30 characters check on the entity level.