### PR TITLE
feat: add MoneyResponseDto

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/common/dtos/money/MoneyResponseDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/common/dtos/money/MoneyResponseDto.java
@@ -1,0 +1,9 @@
+package com.finflow.finflowbackend.common.dtos.money;
+
+import java.math.BigDecimal;
+
+public record MoneyResponseDto(
+    BigDecimal amount,
+    String currencyCode,
+    String currencyName
+) {}


### PR DESCRIPTION
## Description

This PR introduces the `MoneyResponseDto`, which is a common dto and will be implemented inside multiple other dtos that relates to Money object. E.g. AccountDetailsOutDto / SummaryResponseDto or TransactionDetailsOutDto / SummaryResponseDto.

---

## Scope of Change

`MoneyResponseDto` introduces the following three fields:

- `amount`
- `currencyCode`
- `currencyName` to display the full name of the currency