### PR TITLE
feat: add AccountSummaryResponseDto

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/account/dto/AccountSummaryResponseDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/account/dto/AccountSummaryResponseDto.java
@@ -1,0 +1,17 @@
+package com.finflow.finflowbackend.account.dto;
+
+import com.finflow.finflowbackend.common.dtos.money.MoneyResponseDto;
+import com.finflow.finflowbackend.common.enums.AccountOrigin;
+import com.finflow.finflowbackend.common.enums.AccountType;
+
+import java.util.UUID;
+
+public record AccountSummaryResponseDto(
+    UUID accountId,
+    AccountType accountType,
+    AccountOrigin accountOrigin,
+    String providerAccountName,
+    String accountDisplayName,
+    MoneyResponseDto accountMoney,
+    boolean active
+) {}


### PR DESCRIPTION
## Description

This PR introduces `AccountSummaryResponseDto`, its purpose is to display some partial information of the account details when displayed as a list of accounts that the user has in the user dashboard.

---

## Scope of Change

- Add `AccountSummaryResponseDto`

---

## Design considerations

This dto only includes less informative things about the account, for fields such as `accountNumberLast4` or `institutionName`, and `instituationCode` are purposely excluded from this dto.