### PR TITLE
Feat/transaction create dto

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/account/dto/AccountCreateDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/account/dto/AccountCreateDto.java
@@ -1,14 +1,13 @@
 package com.finflow.finflowbackend.account.dto;
 
+import com.finflow.finflowbackend.common.dtos.money.MoneyRequestDto;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
-
-import java.math.BigDecimal;
 
 public record AccountCreateDto(
     @Size(min = 1, max = 30)
     String accountDisplayName,
 
-    @NotNull
     @NotBlank
     @Size(min = 1, max = 30)
     String providerAccountName,
@@ -20,22 +19,24 @@ public record AccountCreateDto(
     @Pattern(regexp = "^\\d{4}$")
     String accountNumberLast4,
 
-    @NotNull
     @NotBlank
     @Size(min = 1, max = 50)
     String institutionName,
 
-    @NotNull
     @NotBlank
     @Size(min = 3, max = 3)
     String institutionCode,
 
     @NotNull
-    @Digits(integer = 13, fraction = 6)
-    BigDecimal accountBalance,
+    @Valid
+    MoneyRequestDto moneyRequest
 
-    @NotNull
-    @NotBlank
-    @Size(min = 3, max = 3)
-    String accountCurrencyCode
+//    @NotNull
+//    @Digits(integer = 13, fraction = 6)
+//    BigDecimal accountBalance,
+//
+//    @NotNull
+//    @NotBlank
+//    @Size(min = 3, max = 3)
+//    String accountCurrencyCode
 ) {}

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/dto/TransactionCreateDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/dto/TransactionCreateDto.java
@@ -1,5 +1,27 @@
 package com.finflow.finflowbackend.transaction.dto;
 
-public record TransactionCreateDto(
+import com.finflow.finflowbackend.common.dtos.money.MoneyRequestDto;
+import com.finflow.finflowbackend.common.enums.CounterpartyType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
+import java.time.LocalDate;
+
+public record TransactionCreateDto(
+    @NotNull
+    @Valid
+    MoneyRequestDto moneyRequest,
+
+    @NotNull
+    LocalDate postedDate,
+
+    @Size(max = 255)
+    String reference,
+
+    @NotBlank
+    @Size(max = 255)
+    String counterpartyName,
+
+    @NotNull
+    CounterpartyType counterpartyType
 ) {}


### PR DESCRIPTION
## Description

This PR introduces the `TransactionCreateDto`, it's used to carry the transaction creation information from the frontend, and sends to the backend to create an account. 

---

## Scope of Change

- Added `TransactionCreateDto`
- Refactored the money related fields inside the `AccountCreateDto`