### PR TITLE
feat: add MoneyResponseMapper

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/common/mapper/MoneyResponseMapper.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/common/mapper/MoneyResponseMapper.java
@@ -1,0 +1,15 @@
+package com.finflow.finflowbackend.common.mapper;
+
+import com.finflow.finflowbackend.common.dtos.money.MoneyResponseDto;
+import com.finflow.finflowbackend.valueobjects.Money;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface MoneyResponseMapper {
+
+    //Money -> MoneyResponseDto
+    @Mapping(source = "currency.code", target = "currencyCode")
+    @Mapping(source = "currency.name", target = "currencyName")
+    MoneyResponseDto toMoneyResponseDto(Money money);
+}


### PR DESCRIPTION
## Description

This PR introduces the `MoneyResponseMapper`, which is used to better maintain the mappings between the money related fields

---

## Scope of Change

- Added `MoneyResponseMapper`

---

## Design Consideration

Because previously, for every mapping between money related field between either from entity to dto, or from dto to entity, the code gets repetitive. By refactoring the code into a generic mapper, it saves the time, and adds more readability to the code