### PR TITLE
feat: add TransactionResponseMapper

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/mapper/TransactionMapper.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/mapper/TransactionMapper.java
@@ -1,4 +1,0 @@
-package com.finflow.finflowbackend.transaction.mapper;
-
-public interface TransactionMapper {
-}

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/mapper/TransactionResponseMapper.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/mapper/TransactionResponseMapper.java
@@ -1,0 +1,23 @@
+package com.finflow.finflowbackend.transaction.mapper;
+
+import com.finflow.finflowbackend.common.mapper.MoneyResponseMapper;
+import com.finflow.finflowbackend.transaction.Transaction;
+import com.finflow.finflowbackend.transaction.dto.TransactionDetailsOutDto;
+import com.finflow.finflowbackend.transaction.dto.TransactionSummaryResponseDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = MoneyResponseMapper.class)
+public interface TransactionResponseMapper {
+
+    //Transaction -> TransactionDetailsOutDto
+    @Mapping(source = "account.id", target = "accountId")
+    @Mapping(source = "transactionMoney", target = "moneyResponse")
+    @Mapping(source = "transactionCategory.id", target = "categoryId")
+    TransactionDetailsOutDto toTransactionDetailsOutDto(Transaction transaction);
+
+    //Transaction -> TransactionSummaryResponseDto
+    @Mapping(source = "transactionMoney", target = "moneyResponse")
+    @Mapping(source = "transactionCategory.id", target = "categoryId")
+    TransactionSummaryResponseDto toTransactionSummaryResponseDto(Transaction transaction);
+}


### PR DESCRIPTION
## Description

This PR introduces the TransactionResponseMapper to provide mappings between the `Transaction` entity to out dtos.

---

## Scope of Change

`TransactionResponseMapper` contains two mapping methods:

- `toTransactionDetailsOutDto`
- `toTransactionSummaryResponseDto`

---

The application runs and executes without issues.