### PR TITLE
feat(mvp-v1): wire up user logics

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/common/enums/UserStatus.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/common/enums/UserStatus.java
@@ -4,5 +4,5 @@ public enum UserStatus {
     ACTIVE,
     PENDING_VERIFICATION,
     SUSPENDED,
-    DELETED
+    DEACTIVATED
 }

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/exception/BusinessRuleViolationException.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/exception/BusinessRuleViolationException.java
@@ -1,0 +1,7 @@
+package com.finflow.finflowbackend.exception;
+
+public class BusinessRuleViolationException extends RuntimeException {
+    public BusinessRuleViolationException(String message) {
+        super(message);
+    }
+}

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/exception/ResourceNotFoundException.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.finflow.finflowbackend.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/user/User.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/user/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -59,10 +60,15 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Setter
     private UserStatus status;
 
     @Column
     private Instant lastLoginAt;
+
+    @Column
+    @Setter
+    private Instant deactivatedAt;
 
     @OneToMany(mappedBy = "user")
     private List<Account> financialAccounts = new ArrayList<>();

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/user/UserController.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/user/UserController.java
@@ -29,9 +29,8 @@ public class UserController {
      */
     @PostMapping
     public ResponseEntity<UserDetailsOutDto> createLocalUser(@RequestBody @Valid LocalUserCreateDto localUserCreateDto) {
-
-        //Complete the body to replace this
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        UserDetailsOutDto createdUser = userService.createLocalUser(localUserCreateDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
 
     /*
@@ -39,9 +38,7 @@ public class UserController {
      */
     @GetMapping("/{userId}")
     public ResponseEntity<UserDetailsOutDto> getUserById(@PathVariable @NotNull UUID userId) {
-
-        //Complete the body to replace this
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        return ResponseEntity.ok(userService.getUserById(userId));
     }
 
     /*
@@ -52,18 +49,17 @@ public class UserController {
             @PathVariable("userId") @NotNull UUID userId,
             @RequestBody @Valid UserPatchDto userPatchDto
     ) {
-
-        //Complete the body to replace this
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        return ResponseEntity.ok(userService.patchUser(userId, userPatchDto));
     }
 
     /*
      * Endpoint: Delete user by id
      */
-    @DeleteMapping("/{userId}")
-    public ResponseEntity<Void> deleteUserById(@PathVariable @NotNull UUID userId) {
 
-        //Complete the body to replace this
+    //In Fintech system, soft delete is always chosen over hard delete.
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> deActiveUserById(@PathVariable @NotNull UUID userId) {
+        userService.deActiveUser(userId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/user/UserRepository.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/user/UserRepository.java
@@ -1,8 +1,17 @@
 package com.finflow.finflowbackend.user;
 
+import com.finflow.finflowbackend.common.enums.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
+
+    //Retrieve the user by userId and userStatus
+    Optional<User> findByUserIdAndStatus(UUID userId, UserStatus status);
+
+    //Retrieve all users
+    List<User> findAllByStatus(UserStatus status);
 }

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/user/service/UserService.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/user/service/UserService.java
@@ -1,9 +1,22 @@
 package com.finflow.finflowbackend.user.service;
 
+import com.finflow.finflowbackend.common.enums.AuthMethod;
+import com.finflow.finflowbackend.common.enums.UserStatus;
+import com.finflow.finflowbackend.exception.ResourceNotFoundException;
+import com.finflow.finflowbackend.user.User;
 import com.finflow.finflowbackend.user.UserRepository;
+import com.finflow.finflowbackend.user.dto.LocalUserCreateDto;
+import com.finflow.finflowbackend.user.dto.UserDetailsOutDto;
+import com.finflow.finflowbackend.user.dto.UserPatchDto;
+import com.finflow.finflowbackend.user.mapper.UserPatchApplier;
 import com.finflow.finflowbackend.user.mapper.UserResponseMapper;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -11,9 +24,65 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserResponseMapper userResponseMapper;
+    private final UserPatchApplier userPatchApplier;
 
-    public UserService(UserRepository userRepository, UserResponseMapper userResponseMapper) {
+    public UserService(UserRepository userRepository, UserResponseMapper userResponseMapper, UserPatchApplier userPatchApplier) {
         this.userRepository = userRepository;
         this.userResponseMapper = userResponseMapper;
+        this.userPatchApplier = userPatchApplier;
+    }
+
+    public UserDetailsOutDto createLocalUser(LocalUserCreateDto localUserCreateDto) {
+        User user = User.createLocalUser(
+                localUserCreateDto.firstName(),
+                localUserCreateDto.lastName(),
+                AuthMethod.LOCAL,
+                localUserCreateDto.email(),
+                localUserCreateDto.phoneNumber(),
+                localUserCreateDto.password(),
+                localUserCreateDto.dateOfBirth(),
+                localUserCreateDto.timeZone()
+        );
+
+        User savedUser = userRepository.save(user);
+        return userResponseMapper.userToUserDetailsOutDto(savedUser);
+    }
+
+    public UserDetailsOutDto getUserById(UUID userId) {
+        User user =  userRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+        return userResponseMapper.userToUserDetailsOutDto(user);
+    }
+
+    public List<UserDetailsOutDto> getAllUsers() {
+        List<User> users = userRepository.findAllByStatus(UserStatus.ACTIVE);
+        List<UserDetailsOutDto> userDetailsOutDtoList = new ArrayList<>();
+        for (User user : users) {
+            userDetailsOutDtoList.add(userResponseMapper.userToUserDetailsOutDto(user));
+        }
+        return userDetailsOutDtoList;
+    }
+
+    public UserDetailsOutDto patchUser(UUID userId, UserPatchDto userPatchDto) {
+        User user = userRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        userPatchApplier.apply(userPatchDto, user);
+
+        User savedUser = userRepository.save(user);
+        return userResponseMapper.userToUserDetailsOutDto(savedUser);
+    }
+
+    public void deActiveUser(UUID userId) {
+        User user = userRepository.findByUserIdAndStatus(userId,  UserStatus.ACTIVE)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        if (user.getStatus() == UserStatus.DEACTIVATED) {
+            //nothing will break, and nothing will happen
+            return;
+        }
+
+        user.setStatus(UserStatus.DEACTIVATED);
+        user.setDeactivatedAt(Instant.now());
     }
 }

--- a/finflow-backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/finflow-backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE users (
     time_zone VARCHAR(100) NOT NULL,
     status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE' CHECK (status IN ('ACTIVE', 'PENDING_VERIFICATION', 'SUSPENDED', 'DELETED')),
     last_login_at TIMESTAMPTZ,
+    deactivated_at TIMESTAMPTZ,
 
     created_at TIMESTAMPTZ NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL,


### PR DESCRIPTION
## Description

This PR introduces the basic logic wireup for the `User` domain, it contains all the basic CRUD endpoints in the `UserController`, and supporting business methods inside the `UserService` and raw data fetching / manipulating method inside the `UserRepository`. 

I also made a few changes to the `UserStatus` class and the User entity, as well as modified the V1 init migration file.

---

## Scope of Change

- Added `UserController` basic CRUD endpoints
- Added supported business methods for CRUD inside the `UserService`
- Added supported repository method inside the `UserRepository`
- Changed the enum constant from `DELETED` to `DEACTIVED` to better match with Fintech system and behaviour
- Added an audit field `deactivedAt` inside the `User` entity
- Added column `deactived_at` inside the `V1__init_migration.sql` file

---

## Design Consideration

A key consideration in this branch is that I purposely changed the user delete mechanism from hard delete to soft delete, which better suits for Fintech systems and behaviours. Because in a standard enterprise-level Fintech system, every piece of data, e.g. the users themselves, and their accounts, and their transactions need to be kept safely. Even when they chose to stop using our service, it's important to just deactive them instead of completely wiping off their data from the database, which is a risky move in the Fintech industry.

In order to do achieve that: 
Instead of just call the `.delete()` method inside the service business method, I set the users new status to `DEACTIVED`, and set the time when they deactived to `Instant.NOW()`.