### PR TITLE
refactor: update the Money vo behaviour

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/account/Account.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/account/Account.java
@@ -55,14 +55,16 @@ public class Account extends BaseEntity {
     private String institutionCode;
 
     @Embedded
-    @AttributeOverride(
-            name = "amount",
-            column = @Column(name = "account_balance", nullable = false, precision = 19, scale = 6)
-    )
-    @AssociationOverride(
-            name = "currency",
-            joinColumns = @JoinColumn(name = "currency_code", referencedColumnName = "code", nullable = false)
-    )
+    @AttributeOverrides({
+            @AttributeOverride(
+                    name = "amount",
+                    column = @Column(name = "account_balance", nullable = false, precision = 19, scale = 6)
+            ),
+            @AttributeOverride(
+                    name = "currencyCode",
+                    column = @Column(name = "account_currency_code", nullable = false, length = 3)
+            )
+    })
     private Money accountMoney;
 
     @Column(nullable = false)
@@ -97,7 +99,7 @@ public class Account extends BaseEntity {
         String instCode = requireNotBlank(institutionCode, "institutionCode cannot be blank").trim();
 
         Money money = Objects.requireNonNull(accountMoney, "accountMoney cannot be null");
-        if (money.getCurrency() == null) throw new IllegalArgumentException("accountMoney currency cannot be null");
+        if (money.getCurrencyCode() == null) throw new IllegalArgumentException("accountMoney currency cannot be null");
         if (money.getAmount() == null) throw new IllegalArgumentException("accountMoney amount cannot be null");
         if (money.getAmount().signum() < 0) throw new IllegalArgumentException("opening balance cannot be negative");
 
@@ -184,7 +186,7 @@ public class Account extends BaseEntity {
         if (newMoney == null) {
             throw new IllegalArgumentException("Money cannot be null");
         }
-        if (!newMoney.getCurrency().equals(this.accountMoney.getCurrency())) {
+        if (!newMoney.getCurrencyCode().equals(this.accountMoney.getCurrencyCode())) {
             throw new IllegalArgumentException("Money currency mismatch");
         }
     }

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/budget/Budget.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/budget/Budget.java
@@ -48,14 +48,16 @@ public class Budget extends BaseEntity {
     private LocalDate startDate;
 
     @Embedded
-    @AttributeOverride(
-            name = "amount",
-            column = @Column(name = "budget_amount", nullable = false, precision = 19, scale = 6)
-    )
-    @AssociationOverride(
-            name = "currency",
-            joinColumns = @JoinColumn(name = "budget_currency_code", referencedColumnName = "code", nullable = false)
-    )
+    @AttributeOverrides({
+            @AttributeOverride(
+                    name = "amount",
+                    column = @Column(name = "budget_amount", nullable = false, precision = 19, scale = 6)
+            ),
+            @AttributeOverride(
+                    name = "currencyCode",
+                    column = @Column(name = "budget_currency_code", nullable = false, length = 3)
+            )
+    })
     private Money budgetMoney;
 
     @Column(nullable = false)
@@ -98,7 +100,13 @@ public class Budget extends BaseEntity {
         budget.periodType = Objects.requireNonNull(periodType, "Period type must not be null");
         budget.customIntervalPeriod = customIntervalPeriod;
         budget.startDate = Objects.requireNonNull(startDate, "Start date must not be null");
-        budget.budgetMoney = Objects.requireNonNull(budgetMoney, "Budget money must not be null");
+
+        Money checkMoney = Objects.requireNonNull(budgetMoney, "budgetMoney cannot be null");
+        if (checkMoney.getCurrencyCode() == null) throw new IllegalArgumentException("budgetMoney currency cannot be null");
+        if (checkMoney.getAmount() == null) throw new IllegalArgumentException("budgetMoney amount cannot be null");
+        if (checkMoney.getAmount().signum() < 0) throw new IllegalArgumentException("budget cannot be negative");
+        budget.budgetMoney = checkMoney;
+
         budget.enableRollover = enableRollover;
         budget.budgetCategory = Objects.requireNonNull(budgetCategory, "Budget category must not be null");
         return budget;

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/common/dtos/money/MoneyResponseDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/common/dtos/money/MoneyResponseDto.java
@@ -4,6 +4,5 @@ import java.math.BigDecimal;
 
 public record MoneyResponseDto(
     BigDecimal amount,
-    String currencyCode,
-    String currencyName
+    String currencyCode
 ) {}

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/common/mapper/MoneyResponseMapper.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/common/mapper/MoneyResponseMapper.java
@@ -9,7 +9,5 @@ import org.mapstruct.Mapping;
 public interface MoneyResponseMapper {
 
     //Money -> MoneyResponseDto
-    @Mapping(source = "currency.code", target = "currencyCode")
-    @Mapping(source = "currency.name", target = "currencyName")
     MoneyResponseDto toMoneyResponseDto(Money money);
 }

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/Transaction.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/Transaction.java
@@ -48,14 +48,16 @@ public class Transaction extends BaseEntity {
     private TransactionType type;
 
     @Embedded
-    @AttributeOverride(
-            name = "amount",
-            column = @Column(name = "transaction_amount", nullable = false, precision = 19, scale = 6)
-    )
-    @AssociationOverride(
-            name = "currency",
-            joinColumns = @JoinColumn(name = "transaction_currency_code", referencedColumnName = "code", nullable = false)
-    )
+    @AttributeOverrides({
+            @AttributeOverride(
+                    name = "amount",
+                    column = @Column(name = "transaction_amount", nullable = false, precision = 19, scale = 6)
+            ),
+            @AttributeOverride(
+                    name = "currencyCode",
+                    column = @Column(name = "transaction_currency_code", nullable = false, length = 3)
+            )
+    })
     private Money transactionMoney;
 
     @Column(name = "posted_date", nullable = false)
@@ -84,7 +86,7 @@ public class Transaction extends BaseEntity {
 
     public static Transaction createTransaction(
             Account account,
-            Money money,
+            Money transactionMoney,
             LocalDate postedDate,
             TransactionDirection direction,
             TransactionType type,
@@ -94,7 +96,12 @@ public class Transaction extends BaseEntity {
     ) {
         Transaction transaction = new Transaction();
         transaction.account = Objects.requireNonNull(account, "account is required");
-        transaction.transactionMoney = Objects.requireNonNull(money, "money is required");
+
+        Money checkMoney = Objects.requireNonNull(transactionMoney, "transactionMoney cannot be null");
+        if (checkMoney.getCurrencyCode() == null) throw new IllegalArgumentException("transactionMoney currency cannot be null");
+        if (checkMoney.getAmount() == null) throw new IllegalArgumentException("transactionMoney amount cannot be null");
+        transaction.transactionMoney = checkMoney;
+
         transaction.postedDate = Objects.requireNonNull(postedDate,  "postedDate is required");
         transaction.counterpartyName = normalizeOrDefault(counterpartyName);
         transaction.counterpartyType = Objects.requireNonNull(counterpartyType, "counterpartyType is required");

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/valueobjects/Money.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/valueobjects/Money.java
@@ -1,10 +1,12 @@
 package com.finflow.finflowbackend.valueobjects;
 
-import com.finflow.finflowbackend.currency.Currency;
 import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.Locale;
+import java.util.Objects;
 
 @Embeddable
 @Getter
@@ -13,33 +15,63 @@ public class Money {
     @Column(nullable = false, precision = 19, scale = 6)
     private BigDecimal amount;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "currency_code", referencedColumnName = "code")
-    private Currency currency;
+//    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @Column(name = "currency_code", nullable = false, length = 3)
+    private String currencyCode;
 
     protected Money(){}
 
-    public Money(BigDecimal amount, Currency currency) {
-        if (amount == null || currency == null) {
-            throw new IllegalArgumentException("Money amount or currency cannot be null");
-        }
-
+    private Money(BigDecimal amount, String currencyCode) {
         this.amount = amount;
-        this.currency = currency;
+        this.currencyCode = currencyCode;
+    }
+
+    public static Money of(BigDecimal amount, String currencyCode) {
+        if (amount == null) throw new IllegalArgumentException("Amount must not be null");
+        if (currencyCode == null || currencyCode.isBlank()) throw new IllegalArgumentException("Currency code must not be blank");
+
+        BigDecimal normalizedAmount = normalizeAmount(amount);
+        String normalizeCurrencyCode = normalizeCurrencyCode(currencyCode);
+        return new Money(normalizedAmount, normalizeCurrencyCode);
+    }
+
+    private static BigDecimal normalizeAmount(BigDecimal amount) {
+        return amount.setScale(2, BigDecimal.ROUND_HALF_UP);
+    }
+
+    private static String normalizeCurrencyCode(String currencyCode) {
+        String trimmedCurrencyCode = currencyCode.trim();
+        if (trimmedCurrencyCode.isBlank()) throw new IllegalArgumentException("Currency code must not be blank");
+        return trimmedCurrencyCode.toUpperCase(Locale.ROOT);
+    }
+
+    /*
+     * For money amount is ZERO 0
+     */
+    public static Money zero(String currencyCode) {
+        return new Money(BigDecimal.ZERO, currencyCode);
     }
 
     public Money add(Money otherMoney) {
         this.requireSameCurrency(otherMoney);
-        return new Money(this.amount.add(otherMoney.getAmount()), this.currency);
+        return new Money(this.amount.add(otherMoney.getAmount()), this.currencyCode);
     }
 
     public Money subtract(Money otherMoney) {
         this.requireSameCurrency(otherMoney);
-        return new Money(this.amount.subtract(otherMoney.getAmount()), this.currency);
+        return new Money(this.amount.subtract(otherMoney.getAmount()), this.currencyCode);
+    }
+
+    /*
+     * For negating the amount
+     */
+    public Money negate() {
+        return Money.of(this.amount.negate(), this.currencyCode);
     }
 
     private void requireSameCurrency(Money otherMoney) {
-        if (!this.currency.equals(otherMoney.currency)) {
+        Objects.requireNonNull(otherMoney, "Money must not be null");
+        if (!this.currencyCode.equals(otherMoney.currencyCode)) {
             throw new IllegalArgumentException("Money currency are not the same");
         }
     }

--- a/finflow-backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/finflow-backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE accounts (
     institution_name VARCHAR(255) NOT NULL,
     institution_code VARCHAR(40) NOT NULL,
     account_balance DECIMAL(19, 6) NOT NULL DEFAULT 0,
-    currency_code VARCHAR(10) NOT NULL,
+    account_currency_code VARCHAR(10) NOT NULL,
     active BOOLEAN NOT NULL DEFAULT TRUE,
     closed_at TIMESTAMPTZ,
 
@@ -55,7 +55,7 @@ CREATE TABLE accounts (
         FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
 
     CONSTRAINT fk_account_currency
-        FOREIGN KEY (currency_code) REFERENCES currencies(code)
+        FOREIGN KEY (account_currency_code) REFERENCES currencies(code)
 );
 
 CREATE TABLE categories (


### PR DESCRIPTION
## Description

The key issue that this PR is attempting to solve is decoupling between the Money VO and the Currency entity. In the modern enterprise-level design, a VO should not know the knowledge about other domains.

---

## Scope of Change

- Refactored Money value object to remove tight coupling to the Currency JPA entity.

- Money now stores currencyCode (String) instead of a @ManyToOne Currency association.

- Added a static factory (Money.of(...)) to centralize validation + normalization (scale/rounding) and prevent inconsistent construction.

- Updated arithmetic methods (add/subtract/...) to compare currencies by currencyCode.

- Updated all the related fields inside `Account`, `Transaction`, and `Budget`.

- Updated the `V1__init_migration.sql` file to make sure the column names are consistent.

---

## Design Consideration

As discussed previously in the description,  the more detailed explanations are the following, explaining why a VO should not be tightly coupled with a domain entity:

- Avoids leaking persistence concerns into the domain/value-object layer (no JPA entity/proxy inside a VO).

- Eliminates common lazy-loading pitfalls (LazyInitializationException) when Money.currency was accessed outside a transaction.

- Improves portability/testability: Money can be used in domain logic without an active persistence context.

- Keeps API/DB semantics clear: Money is a pure value (amount + currency code).

---

## Things to note

Just keep in mind that this refactor is not guaranteed to run with no issues as the logics are not fully implemented. 