### PR TITLE
feat: wire up mvp transaction domain logic

### DIFF
--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/TransactionController.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/TransactionController.java
@@ -28,7 +28,7 @@ public class TransactionController {
      * Endpoint: Add a transaction
      */
     @PostMapping
-    public ResponseEntity<TransactionDetailsOutDto> createTransaction(
+    public ResponseEntity<TransactionDetailsOutDto> createManualTransaction(
             @PathVariable @NotNull UUID userId,
             @PathVariable @NotNull UUID accountId,
             @RequestBody @Valid TransactionCreateDto transactionCreateDto) {
@@ -41,7 +41,7 @@ public class TransactionController {
      * Endpoint: Get a transaction by id
      */
     @GetMapping("/{transactionId}")
-    public ResponseEntity<TransactionDetailsOutDto> getTransaction(
+    public ResponseEntity<TransactionDetailsOutDto> getTransactionById(
             @PathVariable @NotNull UUID userId,
             @PathVariable @NotNull UUID accountId,
             @PathVariable @NotNull UUID transactionId) {
@@ -60,15 +60,5 @@ public class TransactionController {
 
         //Complete the body to replace this
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
-    }
-
-    @DeleteMapping("/{transactionId}")
-    public ResponseEntity<Void> deleteTransaction(
-            @PathVariable @NotNull UUID userId,
-            @PathVariable @NotNull UUID accountId,
-            @PathVariable @NotNull UUID transactionId) {
-
-        //Complete the body to replace this
-        return ResponseEntity.noContent().build();
     }
 }

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/TransactionRepository.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/TransactionRepository.java
@@ -2,7 +2,11 @@ package com.finflow.finflowbackend.transaction;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface TransactionRepository extends JpaRepository<Transaction, UUID> {
+
+    //Find all transactions belong to an account
+    List<Transaction> findAllByAccount_AccountIdOrderByPostedDateDesc(UUID accountId);
 }

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/dto/TransactionCreateDto.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/dto/TransactionCreateDto.java
@@ -2,6 +2,7 @@ package com.finflow.finflowbackend.transaction.dto;
 
 import com.finflow.finflowbackend.common.dtos.money.MoneyRequestDto;
 import com.finflow.finflowbackend.common.enums.CounterpartyType;
+import com.finflow.finflowbackend.common.enums.TransactionType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 
@@ -14,6 +15,9 @@ public record TransactionCreateDto(
 
     @NotNull
     LocalDate postedDate,
+
+    @NotNull
+    TransactionType transactionType,
 
     @Size(max = 255)
     String reference,

--- a/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/service/TransactionService.java
+++ b/finflow-backend/src/main/java/com/finflow/finflowbackend/transaction/service/TransactionService.java
@@ -1,9 +1,27 @@
 package com.finflow.finflowbackend.transaction.service;
 
+import com.finflow.finflowbackend.account.Account;
+import com.finflow.finflowbackend.account.AccountRepository;
+import com.finflow.finflowbackend.common.enums.TransactionDirection;
+import com.finflow.finflowbackend.common.enums.TransactionOrigin;
+import com.finflow.finflowbackend.common.enums.TransactionType;
+import com.finflow.finflowbackend.common.enums.UserStatus;
+import com.finflow.finflowbackend.exception.ResourceNotFoundException;
+import com.finflow.finflowbackend.transaction.Transaction;
 import com.finflow.finflowbackend.transaction.TransactionRepository;
+import com.finflow.finflowbackend.transaction.dto.TransactionCreateDto;
+import com.finflow.finflowbackend.transaction.dto.TransactionDetailsOutDto;
+import com.finflow.finflowbackend.transaction.dto.TransactionSummaryResponseDto;
 import com.finflow.finflowbackend.transaction.mapper.TransactionResponseMapper;
+import com.finflow.finflowbackend.user.User;
+import com.finflow.finflowbackend.user.UserRepository;
+import com.finflow.finflowbackend.valueobjects.Money;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -11,9 +29,73 @@ public class TransactionService {
 
     private final TransactionRepository transactionRepository;
     private final TransactionResponseMapper transactionResponseMapper;
+    private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
 
-    public TransactionService(TransactionRepository transactionRepository, TransactionResponseMapper transactionResponseMapper) {
+    public TransactionService(
+            TransactionRepository transactionRepository,
+            TransactionResponseMapper transactionResponseMapper,
+            UserRepository userRepository,
+            AccountRepository accountRepository
+    ) {
         this.transactionRepository = transactionRepository;
         this.transactionResponseMapper = transactionResponseMapper;
+        this.userRepository = userRepository;
+        this.accountRepository = accountRepository;
+    }
+
+    public TransactionDetailsOutDto createManualTransaction(UUID userId, UUID accountId, TransactionCreateDto transactionCreateDto) {
+        User user = userRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found with id: " + accountId));
+
+        Money money = Money.of(transactionCreateDto.moneyRequest().amount(), transactionCreateDto.moneyRequest().currencyCode());
+
+        TransactionDirection transactionDirection = transactionCreateDto.transactionType() == TransactionType.TRANSFER
+                ? null : transactionCreateDto.transactionType() == TransactionType.CREDIT ? TransactionDirection.IN : TransactionDirection.OUT;
+
+        Transaction transaction = Transaction.createTransaction(
+                account,
+                money,
+                transactionCreateDto.postedDate(),
+                transactionDirection,
+                transactionCreateDto.transactionType(),
+                TransactionOrigin.MANUAL,
+                transactionCreateDto.counterpartyName(),
+                transactionCreateDto.counterpartyType()
+        );
+
+        Transaction savedTransaction = transactionRepository.save(transaction);
+        return transactionResponseMapper.toTransactionDetailsOutDto(savedTransaction);
+    }
+
+    public TransactionDetailsOutDto getTransactionById(UUID userId, UUID accountId, UUID transactionId) {
+        User user = userRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found with id: " + accountId));
+
+        Transaction transaction = transactionRepository.findById(transactionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transaction not found with id: " + transactionId));
+
+        return transactionResponseMapper.toTransactionDetailsOutDto(transaction);
+    }
+
+    public List<TransactionSummaryResponseDto> getAllTransactions(UUID userId, UUID accountId) {
+        User user = userRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found with id: " + accountId));
+
+        List<Transaction> transactions = transactionRepository.findAllByAccount_AccountIdOrderByPostedDateDesc(account.getId());
+        List<TransactionSummaryResponseDto> transactionSummaryResponseDtoList = new ArrayList<>();
+        for (Transaction transaction : transactions) {
+            transactionSummaryResponseDtoList.add(transactionResponseMapper.toTransactionSummaryResponseDto(transaction));
+        }
+        return transactionSummaryResponseDtoList;
     }
 }


### PR DESCRIPTION
## Description

This PR introduces the mvp-level `Transaction` domain logic, including the basic CRUD-style endpoints and the supporting business logic methods inside the service layer.

---

## Scope of Change

- Added `TransactionController`
- Added 'TransactionService`, where the business logic lives
- Added `TransactionRepository`